### PR TITLE
Reconfiguring matplotlib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
+htmlcov
 
 # Translations
 *.mo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Note: The command-line interface and the format and content of input, output and
 ### Fixed
 - Removed deprecated parameter "iid" for grid search since scikit-learn 0.22.
 - Fixed a bug in custom genome exclusion during database building.
+- Fixed a bug which breaks the program when the temporary directory (tmpdir) is not specified.
+- Allowed matplotlib to generate figures when it cannot open X window (e.g., in a remote server).
 
 
 ## Version 2.0b1 (complete rework) (10/23/2019)

--- a/hgtector/analyze.py
+++ b/hgtector/analyze.py
@@ -24,6 +24,8 @@ from sklearn.neighbors import KernelDensity, NearestCentroid
 from sklearn.model_selection import GridSearchCV
 from sklearn.metrics import silhouette_samples
 
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
 from hgtector.util import (


### PR DESCRIPTION
Addressed issue #54 . Now HGTector lets matplotlib use Agg as backend so that it can generate figures even when the computer does not have a graphical interface (e.g., `ssh` instead of `ssh -X` into a remote server).