### PR TITLE
Removing only trailing breaklines from search results

### DIFF
--- a/hgtector/analyze.py
+++ b/hgtector/analyze.py
@@ -276,7 +276,7 @@ class Analyze(object):
         data = []
         with read_file(file) as f:
             for line in f:
-                line = line.rstrip("\n")
+                line = line.rstrip('\r\n')
                 m = p.match(line)
                 if m:
                     if m.group(1) == 'ID':

--- a/hgtector/analyze.py
+++ b/hgtector/analyze.py
@@ -276,7 +276,7 @@ class Analyze(object):
         data = []
         with read_file(file) as f:
             for line in f:
-                line = line.rstrip()
+                line = line.rstrip("\n")
                 m = p.match(line)
                 if m:
                     if m.group(1) == 'ID':


### PR DESCRIPTION
hgtector analyze fails when Product line from search is empty (Issue https://github.com/DittmarLab/HGTector/issues/57).

This has my proposed fix.